### PR TITLE
購入記録作成への導線追加、コーヒー豆登録を同一ページでモーダル化

### DIFF
--- a/app/controllers/beans_controller.rb
+++ b/app/controllers/beans_controller.rb
@@ -22,7 +22,7 @@ class BeansController < ApplicationController
   def create
     @bean = Bean.new(bean_params)
     if @bean.save
-      redirect_to beans_path(region: params[:bean][:region_id]), success: t('defaults.message.registered', item: Bean.model_name.human)
+      flash.now[:success] = t('defaults.message.registered', item: Bean.model_name.human)
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,5 +10,8 @@ application.register("hello", HelloController)
 import LocationController from "./location_controller"
 application.register("location", LocationController)
 
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)
+
 import ToastController from "./toast_controller"
 application.register("toast", ToastController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+import { Modal } from "bootstrap"
+
+// Connects to data-controller="modal"
+export default class extends Controller {
+  connect() {
+    this.modal = new Modal(this.element)
+    this.modal.show()
+  }
+
+  close(event) {
+    if (event.detail.success) {
+      this.modal.hide()
+    }
+  }
+}

--- a/app/views/beans/create.turbo_stream.slim
+++ b/app/views/beans/create.turbo_stream.slim
@@ -1,0 +1,1 @@
+= turbo_stream_flash

--- a/app/views/beans/new.html.slim
+++ b/app/views/beans/new.html.slim
@@ -1,10 +1,7 @@
-- assign_meta_tags title: t('.title')
-.container.mb-3
-  .col-md-10.offset-md-1.col-lg-8.offset-lg-2.col-xl-6.offset-xl-3
-    .d-flex.justify-content-between.mb-3.mt-5.align-items-center
-      h1.mb-0 = t('.title')
-      = link_to t('defaults.cancel'), mypage_purchases_path, class: 'btn btn-outline-info'
-    = bootstrap_form_with model: @bean do |f|
+= render 'shared/modal', title: t('.title') do
+  - assign_meta_tags title: t('.title')
+  = turbo_frame_tag @bean do
+    = bootstrap_form_with model: @bean, data: { action: "turbo:submit-end->modal#close" } do |f|
       = f.text_field :name
       = f.select :roast, Bean.roasts_i18n.invert, prompt: Bean.human_attribute_name(:roast)
       = f.select :fineness, Bean.finenesses_i18n.invert, prompt: Bean.human_attribute_name(:fineness)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -3,6 +3,7 @@ html
   head
     meta[name="google-site-verification" content="#{ ENV['GOOGLE_SITE_VERIFICATION_CONTENT'].html_safe }"]
     meta[name="viewport" content="width=device-width,initial-scale=1"]
+    meta[name="turbo-cache-control" content="no-cache"]
     = csrf_meta_tags
     = csp_meta_tag
     = show_meta_tags
@@ -25,5 +26,6 @@ html
       = render 'shared/before_login_header'
     = yield
     = render 'shared/footer'
+    = turbo_frame_tag 'modal'
     #flashes.position-fixed.top-0.end-0.m-2
       = render 'shared/flash'

--- a/app/views/purchases/_form.html.slim
+++ b/app/views/purchases/_form.html.slim
@@ -9,7 +9,7 @@
     ul.z-1.list-group.position-absolute.top-100.start-0[data-autocomplete-target="results"]
   .d-flex.align-items-center.justify-content-around
     p.mb-0 = t('defaults.no_candidates', item: Bean.model_name.human)
-    = link_to t('defaults.register', item: Bean.model_name.human), new_bean_path, class: 'btn btn-outline-secondary'
+    = link_to t('defaults.register', item: Bean.model_name.human), new_bean_path, class: 'btn btn-outline-secondary', data: { turbo_frame: 'modal' }
   .form-group.mb-3.position-relative[data-controller="autocomplete" data-autocomplete-url-value="/beans/search" role="combobox"]
     = f.label :bean_name,Bean.human_attribute_name(:name), class: 'form-label'
     = f.text_field :bean_name, wrapper: false , data: { autocomplete_target: "input" }

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -11,9 +11,11 @@ header.bg-641f1f
             = link_to t('defaults.shop'), shops_path, class: 'nav-link active fs-4'
         ul.navbar-nav
           li.nav-item.dropdown
-            a.nav-link.dropdown-toggle.active.fs-4.ms-4 href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false" = t('defaults.menu')
+            a.nav-link.dropdown-toggle.active.fs-4.ms-5 href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false" = t('defaults.menu')
             ul.dropdown-menu
               li
                 = link_to t('defaults.mypage'), mypage_purchases_path, class: 'dropdown-item fs-5'
+              li
+                = link_to t('purchases.new.title'), new_purchase_path, class: 'dropdown-item fs-5'
               li
                 = link_to t('defaults.logout'), logout_path, data: { turbo_confirm: t('defaults.logout_confirm') , turbo_method: :delete }, class: 'dropdown-item fs-5'

--- a/app/views/shared/_modal.html.slim
+++ b/app/views/shared/_modal.html.slim
@@ -1,0 +1,9 @@
+= turbo_frame_tag 'modal' do
+  .modal.fade data-controller="modal"
+    .modal-dialog
+      .modal-content
+        .modal-header
+          h5.modal-title = title
+          button.btn-close type='button' data-bs-dismiss="modal" aria-label="Close"
+        .modal-body
+          = yield

--- a/app/views/shops/new.html.slim
+++ b/app/views/shops/new.html.slim
@@ -3,7 +3,7 @@
   .col-md-10.offset-md-1.col-lg-8.offset-lg-2.col-xl-6.offset-xl-3
     .d-flex.justify-content-between.mb-3.mt-5
       h1.mb-0 = t('.title')
-      = link_to t('default.cancel'), mypage_purchases_path, class: 'btn btn-outline-info my-2'
+      = link_to t('defaults.cancel'), mypage_purchases_path, class: 'btn btn-outline-info my-2'
     = bootstrap_form_with model: @shop do |f|
       - if f.object.errors.present?
         .alert.alert-danger
@@ -21,7 +21,7 @@
 
       css:
         #map-new {
-          height: 400px;
+          height: 25rem;
         }
 
       = f.submit

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -21,7 +21,7 @@ ja:
       input: "%{item}を入力してください"
       require_login: 'ログインしてください'
       created: "%{item}を作成しました"
-      registerd: "%{item}を登録しました"
+      registered: "%{item}を登録しました"
       not_created: "%{item}を作成できませんでした"
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新できませんでした"


### PR DESCRIPTION
- [x] ヘッダーのドロップダウンに購入記録作成へのリンクを追加
----
- [x] application.html.slimにmodal用の要素を追加
- [x] モーダル用stimulus controller追加
- [x] コーヒー豆登録をモーダル化