### PR TITLE
Reviewモデルへ画像カラムの追加、Beanモデルから画像カラムの削除

### DIFF
--- a/app/controllers/admin/beans_controller.rb
+++ b/app/controllers/admin/beans_controller.rb
@@ -44,6 +44,6 @@ class Admin::BeansController < Admin::BaseController
   end
 
   def bean_params
-    params.require(:bean).permit(:name, :roast, :fineness, :image, :image_cache, :region_id)
+    params.require(:bean).permit(:name, :roast, :fineness, :region_id)
   end
 end

--- a/app/controllers/admin/reviews_controller.rb
+++ b/app/controllers/admin/reviews_controller.rb
@@ -29,6 +29,6 @@ class Admin::ReviewsController < Admin::BaseController
   end
 
   def review_params
-    params.require(:review).permit(:title, :fineness, :evaluation, :content, :brewing_method_id,)
+    params.require(:review).permit(:title, :fineness, :evaluation, :content, :brewing_method_id, :image, :image_cache)
   end
 end

--- a/app/controllers/beans_controller.rb
+++ b/app/controllers/beans_controller.rb
@@ -36,6 +36,6 @@ class BeansController < ApplicationController
   private
 
   def bean_params
-    params.require(:bean).permit(:name, :roast, :fineness, :region_id, :image)
+    params.require(:bean).permit(:name, :roast, :fineness, :region_id)
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -31,7 +31,7 @@ class ReviewsController < ApplicationController
   private
 
   def review_params
-    params.require(:review).permit(:title, :fineness, :evaluation, :content, :brewing_method_id)
+    params.require(:review).permit(:title, :fineness, :evaluation, :content, :brewing_method_id, :image, :image_cache)
   end
 
   def set_review

--- a/app/models/bean.rb
+++ b/app/models/bean.rb
@@ -27,7 +27,12 @@ class Bean < ApplicationRecord
     # reviews.average(:evaluation)
     # evs = reviews.pluck(:evaluation)
     evs = reviews.map { |review| review.evaluation }
-    evs.sum.fdiv(evs.length)
+    evs.sum.fdiv(evs.length).round(2)
+  end
+
+  def image_url
+    review_with_image = reviews.where.not(image: nil).order(like_count: :desc).limit(1)[0]
+    review_with_image ? review_with_image.image.url : 'noimage.jpg'
   end
 
   private

--- a/app/models/bean.rb
+++ b/app/models/bean.rb
@@ -1,6 +1,4 @@
 class Bean < ApplicationRecord
-  mount_uploader :image, ImageUploader
-
   belongs_to :region
   has_many :dealers, dependent: :destroy
   has_many :shops, through: :dealers

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -22,7 +22,7 @@ class Review < ApplicationRecord
   enum :fineness, { grinded: 0, coarsely: 10, medium: 20, medium_fine: 30, fine: 40, superfine: 50 }, prefix: true
 
   def self.ransackable_attributes(auth_object = nil)
-    auth_object&.admin? ? super : %w(title)
+    auth_object&.admin? ? super : %w(title evaluation created_at like_count)
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,6 +1,8 @@
 class Review < ApplicationRecord
   include GroupByDay
 
+  mount_uploader :image, ImageUploader
+
   belongs_to :purchase
   belongs_to :brewing_method
   has_many :review_tools, dependent: :destroy

--- a/app/views/admin/beans/_form.html.slim
+++ b/app/views/admin/beans/_form.html.slim
@@ -2,9 +2,5 @@
   = f.text_field :name
   = f.select :roast, Bean.roasts.keys.to_a
   = f.select :fineness, Bean.finenesses.keys.to_a
-  = f.file_field :image, id: 'file-field'
-  = f.hidden_field :image_cache
-  .mb-3#preview-field
-    = image_tag bean.image.url, id: 'preview', class: 'image-preview object-fit-cover'
   = f.select :region_id, Region.pluck(:name, :id)
   = f.submit

--- a/app/views/admin/beans/index.html.slim
+++ b/app/views/admin/beans/index.html.slim
@@ -22,7 +22,7 @@
         .col-1
           = sort_link(@q, :fineness, class: 'link-dark')
         .col-2
-          = sort_link(@q, :region, class: 'link-dark')
+          = sort_link(@q, :region_name, Region.model_name.human, class: 'link-dark')
         .col-1
           | pcs/rvw
         .col-2

--- a/app/views/admin/beans/index.html.slim
+++ b/app/views/admin/beans/index.html.slim
@@ -9,10 +9,10 @@
     = search_form_for @q, url: admin_beans_path, html: { data: { turbo_frame: "beans-list" } },
                       class: 'input-group mb-3 ms-0' do |f|
       = f.text_field :name_cont, class: 'form-control', placeholder: 'name'
-      = f.select :roast_eq, Bean.roasts.keys.to_a, class: 'form-select px-4', prompt: 'roast'
-      = f.select :fineness_eq, Bean.finenesses.keys.to_a, class: 'form-select px-4', prompt: 'fineness'
-      = f.select :region_name_eq, Region.pluck(:name), class: 'form-select px-4', prompt: 'region'
-      = f.submit '検索', class: 'btn btn-primary px-4'
+      = f.select :roast_eq, Bean.roasts.keys.to_a, { prompt: 'roast' }, { class: 'form-select' }
+      = f.select :fineness_eq, Bean.finenesses.keys.to_a, { prompt: 'fineness' }, { class: 'form-select' }
+      = f.select :region_name_eq, Region.pluck(:name), { prompt: 'region' }, { class: 'form-select' }
+      = f.submit '検索', class: 'btn btn-primary'
     = turbo_frame_tag 'bean-list' do
       .row.border-bottom.pb-1
         .col-3

--- a/app/views/admin/purchases/index.html.slim
+++ b/app/views/admin/purchases/index.html.slim
@@ -10,9 +10,9 @@
                       class: 'input-group mb-3 ms-0' do |f|
       = f.text_field :bean_name_cont, class: 'form-control', placeholder: 'bean name'
       = f.text_field :shop_name_cont, class: 'form-control', placeholder: 'shop name'
-      = f.select :store_roast_option_eq, Purchase.store_roast_options.keys.to_a, class: 'form-select px-4', prompt: 'roast'
-      = f.select :store_grind_option_eq, Purchase.store_grind_options.keys.to_a, class: 'form-select px-4', prompt: 'fineness'
-      = f.submit '検索', class: 'btn btn-primary px-4'
+      = f.select :store_roast_option_eq, Purchase.store_roast_options.keys.to_a, { prompt: 'roast' }, { class: 'form-select' }
+      = f.select :store_grind_option_eq, Purchase.store_grind_options.keys.to_a, { prompt: 'fineness' }, { class: 'form-select' }
+      = f.submit '検索', class: 'btn btn-primary'
     = turbo_frame_tag 'purchases-list' do
       .row.border-bottom.pb-1
         .col-2

--- a/app/views/admin/reviews/edit.html.slim
+++ b/app/views/admin/reviews/edit.html.slim
@@ -17,4 +17,8 @@
           - 1.upto(5) do |i|
             = f.radio_button :evaluation, i, label: i, inline: true
       = f.text_area :content
+      = f.file_field :image, id: 'file-field'
+      = f.hidden_field :image_cache
+      .mb-3#preview-field
+        = image_tag @review.image.url, id: 'preview', class: 'image-preview object-fit-cover'
       = f.submit

--- a/app/views/admin/reviews/index.html.slim
+++ b/app/views/admin/reviews/index.html.slim
@@ -11,8 +11,8 @@
       = f.text_field :title_cont, class: 'form-control', placeholder: 'title'
       = f.text_field :content_cont, class: 'form-control', placeholder: 'content'
       = f.text_field :purchase_bean_name_cont, class: 'form-control', placeholder: 'bean name'
-      = f.select :fineness_eq, Review.finenesses.keys.to_a, class: 'form-select px-4', prompt: 'fineness'
-      = f.select :evaluation_eq, (1..5).to_a, class: 'form-select px-4', prompt: 'evaluation'
+      = f.select :fineness_eq, Review.finenesses.keys.to_a, { prompt: 'fineness' }, { class: 'form-select' }
+      = f.select :evaluation_eq, (1..5).to_a, { prompt: 'evaluation' },{  class: 'form-select' }
       = f.submit '検索', class: 'btn btn-primary px-4'
     = turbo_frame_tag 'reviews-list' do
       .row.border-bottom.pb-1

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -10,8 +10,8 @@
                       class: 'input-group mb-3 ms-0' do |f|
       = f.text_field :name_cont, class: 'form-control', placeholder: 'name'
       = f.text_field :email_cont, class: 'form-control', placeholder: 'email'
-      = f.select :role_eq, User.roles.keys.to_a, class: 'form-select px-4', prompt: 'role'
-      = f.submit '検索', class: 'btn btn-primary px-4'
+      = f.select :role_eq, User.roles.keys.to_a, { prompt: 'role' }, { class: 'form-select' }
+      = f.submit '検索', class: 'btn btn-primary'
     = turbo_frame_tag 'user-list' do
       .row.border-bottom.pb-1
         .col-3

--- a/app/views/beans/_bean.html.slim
+++ b/app/views/beans/_bean.html.slim
@@ -1,7 +1,7 @@
 = link_to bean_path(bean), data: { turbo_frame: '_top' }, class: 'card mb-3 text-decoration-none' do
   .row.g-0
     .col-md-12.col-xl-4.col-lg-5
-      = image_tag bean.image.url, class:'img-fluid rounded col-12'
+      = image_tag bean.image_url, class:'img-fluid rounded col-12'
     .col-md-12.col-xl-8.col-lg-7
       .card-body.py-2
         h5.card-title.mb-1  = bean.name

--- a/app/views/beans/_bean.html.slim
+++ b/app/views/beans/_bean.html.slim
@@ -1,7 +1,7 @@
-= link_to bean_path(bean), data: { turbo_frame: '_top' }, class: 'card mb-3 text-decoration-none' do
+= link_to bean_path(bean), data: { turbo_frame: '_top' }, class: 'card mb-3 text-decoration-none shadow-sm' do
   .row.g-0
     .col-md-12.col-xl-4.col-lg-5
-      = image_tag bean.image_url, class:'img-fluid rounded col-12'
+      = image_tag bean.image_url, class:'img-fluid rounded col-12 shadow-sm'
     .col-md-12.col-xl-8.col-lg-7
       .card-body.py-2
         h5.card-title.mb-1  = bean.name
@@ -15,6 +15,6 @@
         .bg-body-secondary
           - if bean.reviews.present?
             - bean.reviews.limit(3).each do |review|
-              p.card-text.mb-0.fs-7 = review.title
+              p.card-text.mb-0.lh-1.fs-7 = review.title
           - else
             p = t('defaults.nothing', item: Review.model_name.human)

--- a/app/views/beans/_review.html.slim
+++ b/app/views/beans/_review.html.slim
@@ -1,23 +1,29 @@
 .card.p-3.mb-2 id="review_#{review.id}"
-  .row
-    .d-flex.align-items-center.mb-2
-      = link_to user_profile_path(review.user), class: 'me-3', data: { turbo_frame: '_top' } do
-        = image_tag review.user.avatar.url, size: '70x70', class: 'rounded-circle'
+  .d-flex.align-items-center.mb-2
+    = link_to user_profile_path(review.user), class: 'me-3', data: { turbo_frame: '_top' } do
+      = image_tag review.user.avatar.url, size: '70x70', class: 'rounded-circle'
+    .d-flex.flex-wrap.align-items-center
+      = link_to user_profile_path(review.user), class: 'link-dark me-3', data: { turbo_frame: '_top' } do
+        h6.mb-0 = review.user.name
       .d-flex.flex-wrap.align-items-center
-        = link_to user_profile_path(review.user), class: 'link-dark me-3', data: { turbo_frame: '_top' } do
-          h6.mb-0 = review.user.name
-        .d-flex.flex-wrap.align-items-center
-          .badge.rounded-pill.text-bg-secondary.me-2
-            i.bi.bi-star
-            span = review.evaluation
-          .badge.rounded-pill.text-bg-secondary.my-1.me-2.d-flex.flex-wrap.pe-1
-            - if review.tools.present?
-              - review.tools.each do |tool|
-                span.badge.rounded-pill.text-bg-light.me-1.ms-0 = tool.name
-            - else
-              span = t('defaults.unregistered', item: Tool.model_name.human)
-          .badge.rounded-pill.text-bg-secondary
-            span = review.brewing_method.name
+        .badge.rounded-pill.text-bg-secondary.me-2
+          i.bi.bi-star
+          span = review.evaluation
+        .badge.rounded-pill.text-bg-secondary.my-1.me-2.d-flex.flex-wrap.pe-1
+          - if review.tools.present?
+            - review.tools.each do |tool|
+              span.badge.rounded-pill.text-bg-light.me-1.ms-0 = tool.name
+          - else
+            span = t('defaults.unregistered', item: Tool.model_name.human)
+        .badge.rounded-pill.text-bg-secondary
+          span = review.brewing_method.name
+  - if review.image.present?
+    .d-flex.mb-1
+      div
+        h5 = review.title
+        = simple_format(review.content, class: 'mb-0')
+      = image_tag review.image.url, size: '200x150', class: 'ms-auto shadow'
+  - else
     h5 = review.title
     = simple_format(review.content, class: 'mb-0')
   - if current_user

--- a/app/views/beans/new.html.slim
+++ b/app/views/beans/new.html.slim
@@ -6,8 +6,4 @@
       = f.select :roast, Bean.roasts_i18n.invert, prompt: Bean.human_attribute_name(:roast)
       = f.select :fineness, Bean.finenesses_i18n.invert, prompt: Bean.human_attribute_name(:fineness)
       = f.select :region_id, Region.pluck(:name, :id), prompt: Region.model_name.human
-      = f.file_field :image, id: 'file-field'
-      = f.hidden_field :image_cache
-      .mb-3#preview-field
-        = image_tag @bean.image.url, id: 'preview', class: 'image-preview object-fit-cover'
       = f.submit

--- a/app/views/beans/show.html.slim
+++ b/app/views/beans/show.html.slim
@@ -1,8 +1,8 @@
-- assign_meta_tags title: @bean.name, image: @bean.image.url
+- assign_meta_tags title: @bean.name, image: @bean.image_url
 .container.mb-3
-  .col-md-10.offset-md-1.col-lg-8.offset-lg-2
+  .col-md-10.offset-md-1
     .row.my-3
-      = image_tag @bean.image.url, class: 'col-10 offset-1 col-xs-8 offset-xs-2 col-sm-6 offset-sm-0'
+      = image_tag @bean.image_url, class: 'col-10 offset-1 col-xs-8 offset-xs-2 col-sm-6 offset-sm-0'
       .d-flex.justify-content-between.mt-3.col-sm-6
         .text-center.col-10
           h4 = @bean.name

--- a/app/views/reviews/_form.html.slim
+++ b/app/views/reviews/_form.html.slim
@@ -10,4 +10,8 @@
       - 1.upto(5) do |i|
         = f.radio_button :evaluation, i, label: i, inline: true
   = f.text_area :content
+  = f.file_field :image, id: 'file-field'
+  = f.hidden_field :image_cache
+  .mb-3#preview-field
+    = image_tag review.image.url, id: 'preview', class: 'image-preview object-fit-cover'
   = f.submit

--- a/app/views/user_profiles/show.html.slim
+++ b/app/views/user_profiles/show.html.slim
@@ -15,7 +15,8 @@
     = render 'shared/user_profile', user: @user
     = turbo_frame_tag 'review-list' do
       .d-flex.justify-content-end
-        = sort_link(@q, :purchase_bean_name, 'Bean name', class: 'link-dark ms-1')
+        = sort_link(@q, :title, class: 'link-dark')
+        = sort_link(@q, :purchase_bean_name, class: 'link-dark ms-1')
         = sort_link(@q, :created_at, class: 'link-dark ms-1')
       - if @reviews.present?
         .accordion#accordionreviews.accordion-flush

--- a/db/migrate/20240227041311_add_review_image.rb
+++ b/db/migrate/20240227041311_add_review_image.rb
@@ -1,0 +1,6 @@
+class AddReviewImage < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :beans, :image, :json
+    add_column :reviews, :image, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_24_162956) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_27_041311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,7 +31,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_24_162956) do
     t.bigint "region_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.json "image"
     t.index ["region_id"], name: "index_beans_on_region_id"
   end
 
@@ -123,6 +122,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_24_162956) do
     t.datetime "updated_at", null: false
     t.bigint "purchase_id"
     t.integer "like_count", default: 0, null: false
+    t.json "image"
     t.index ["brewing_method_id"], name: "index_reviews_on_brewing_method_id"
     t.index ["purchase_id"], name: "index_reviews_on_purchase_id", unique: true
   end


### PR DESCRIPTION
- [x] DBへの変更適用
- [x] レビュー投稿フォームへ写真用のフィールド追加
- [x] コーヒー豆登録フォームから画像フィールドを削除
- [x] コーヒー豆詳細などの画像は写真付きのレビューから最もいいねがついたものを利用
- [x] レビューのパーシャルにimage_tagを追加