### PR TITLE
Shop自動登録機能

### DIFF
--- a/app/controllers/admin/purchases_controller.rb
+++ b/app/controllers/admin/purchases_controller.rb
@@ -27,7 +27,7 @@ class Admin::PurchasesController < Admin::BaseController
   private
 
   def purchase_form_params
-    params.require(:purchase).permit(:shop_name, :bean_name,
+    params.require(:purchase).permit(:shop_name, :shop_place_id, :bean_name, :bean_id,
       :store_roast_option, :store_grind_option, :purchase_at).merge(user_id: current_user.id)
   end
 

--- a/app/controllers/admin/shops_controller.rb
+++ b/app/controllers/admin/shops_controller.rb
@@ -12,6 +12,7 @@ class Admin::ShopsController < Admin::BaseController
 
   def create
     @shop = Shop.new(shop_params)
+    @shop.add_google_map_uri
 
     if @shop.save
       redirect_to admin_shops_path, success: 'create successful'
@@ -42,6 +43,6 @@ class Admin::ShopsController < Admin::BaseController
   end
 
   def shop_params
-    params.require(:shop).permit(:name, :place_id, :address, :phone_number, :latitude, :longitude)
+    params.require(:shop).permit(:name, :place_id, :address, :latitude, :longitude, :google_map_uri)
   end
 end

--- a/app/controllers/beans_controller.rb
+++ b/app/controllers/beans_controller.rb
@@ -30,7 +30,7 @@ class BeansController < ApplicationController
   end
 
   def search
-    @beans = Bean.where("name like ?", "%#{params[:q]}%")
+    @beans = Bean.where("name like ?", "%#{params[:q]}%").includes(purchases: :shop)
     render layout: false
   end
 

--- a/app/controllers/beans_controller.rb
+++ b/app/controllers/beans_controller.rb
@@ -11,6 +11,7 @@ class BeansController < ApplicationController
 
   def show
     @bean = Bean.find(params[:id])
+    @shops = @bean.shops.limit(2)
     @q = @bean.reviews.ransack(params[:q])
     @reviews = @q.result.includes(:tools, :brewing_method, :liked_users, purchase: :user).page(params[:page])
   end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -29,7 +29,7 @@ class PurchasesController < ApplicationController
   private
 
   def purchase_form_params
-    params.require(:purchase).permit(:shop_name, :bean_name,
+    params.require(:purchase).permit(:shop_name, :shop_place_id, :bean_name, :bean_id,
       :store_roast_option, :store_grind_option, :purchase_at).merge(user_id: current_user.id)
   end
 

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -16,7 +16,7 @@ class ShopsController < ApplicationController
         @search_explanation = @shops.first.name
       end
     else
-      @shops = Shop.near([35.6809591, 139.7673068], 10, units: :km)
+      @shops = Shop.near([35.6809591, 139.7673068], 3, units: :km)
       @search_explanation = t('.arround_tokyo')
     end
   end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -27,6 +27,7 @@ class ShopsController < ApplicationController
 
   def create
     @shop = Shop.new(shop_params)
+    @shop.add_google_map_uri
 
     if @shop.save
       redirect_to mypage_purchases_path, success: t('defaults.message.registered', item: Shop.model_name.human)
@@ -43,6 +44,6 @@ class ShopsController < ApplicationController
   private
 
   def shop_params
-    params.require(:shop).permit(:name, :place_id, :address, :phone_number, :latitude, :longitude)
+    params.require(:shop).permit(:name, :place_id, :address, :latitude, :longitude)
   end
 end

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -6,7 +6,7 @@ class TopsController < ApplicationController
     @regions = Region.all
     @q = Review.ransack(params[:q])
 
-    @reviews = if current_user && current_user.recommended_reviews.present?
+    @reviews = if current_user&.recommended_reviews.present?
                  current_user.recommended_reviews.includes(:brewing_method, purchase: :bean).page(params[:page]).per(10)
                else
                  Review.all.includes(:brewing_method, purchase: :bean).page(params[:page]).per(10)

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -7,7 +7,7 @@ class TopsController < ApplicationController
     @q = Review.ransack(params[:q])
 
     @reviews = if current_user && current_user.recommended_reviews.present?
-                 current_user.recommended_reviews.includes(:brewing_method, purchase: :bean)
+                 current_user.recommended_reviews.includes(:brewing_method, purchase: :bean).page(params[:page]).per(10)
                else
                  Review.all.includes(:brewing_method, purchase: :bean).page(params[:page]).per(10)
                end

--- a/app/form/purchase_form.rb
+++ b/app/form/purchase_form.rb
@@ -3,7 +3,9 @@ class PurchaseForm
   include ActiveModel::Attributes
 
   attribute :shop_name, :string
+  attribute :shop_place_id, :string
   attribute :bean_name, :string
+  attribute :bean_id, :integer
   attribute :store_roast_option, :string
   attribute :store_grind_option, :string
   attribute :purchase_at, :date
@@ -37,6 +39,7 @@ class PurchaseForm
 
   def save
     return false if invalid?
+
     ActiveRecord::Base.transaction do
       # binding.pry
       @purchase.assign_attributes(user_id: user_id, shop_id: shop.id, bean_id: bean.id,
@@ -80,20 +83,22 @@ class PurchaseForm
   def default_attributes
     {
       shop_name: @purchase.shop.name,
+      shop_place_id: @purchase.shop.place_id,
       bean_name: @purchase.bean.name,
+      bean_id: @purchase.bean_id,
       purchase_at: @purchase.purchase_at,
       store_roast_option: @purchase.store_roast_option,
       store_grind_option: @purchase.store_grind_option,
-      user_id: @purchase.user.id
+      user_id: @purchase.user_id
     }
   end
 
   def bean
-    @bean ||= Bean.find_by(name: bean_name)
+    @bean ||= Bean.find_by(id: bean_id)
   end
 
   def shop
-    @shop ||= Shop.find_by(name: shop_name)
+    @shop ||= Shop.find_by(place_id: shop_place_id)
   end
 
   # def purchase
@@ -125,10 +130,10 @@ class PurchaseForm
   end
 
   def product_does_not_exist
-    errors.add(:bean_name, "商品が存在しません") unless bean# Bean.find_by(name: self.bean_name)
+    errors.add(:bean_name, "商品が存在しません") unless bean_id.present? && bean # Bean.find_by(name: self.bean_name)
   end
 
   def shop_does_not_exist
-    errors.add(:shop_name, "店舗が存在しません") unless shop # Shop.find_by(name: self.shop_name)
+    errors.add(:shop_name, "店舗が存在しません") unless shop_place_id.present? && shop # Shop.find_by(name: self.shop_name)
   end
 end

--- a/app/javascript/shop_index.js
+++ b/app/javascript/shop_index.js
@@ -9,7 +9,7 @@ const initIndexMap = () => {
 
     const map = new google.maps.Map(document.getElementById("map-index"), {
       center: {lat: currentLat || 35.6809591, lng: currentLng || 139.7673068},
-      zoom: 9,
+      zoom: 13,
     });
 
     const list = document.getElementById("accordionShops");

--- a/app/javascript/shop_new.js
+++ b/app/javascript/shop_new.js
@@ -10,13 +10,12 @@ function initNewMap() {
   const formnName = document.getElementById("form-name");
   const formPlaceId = document.getElementById("form-place-id");
   const formAddress = document.getElementById("form-address");
-  const formPhonenuber = document.getElementById("form-phonenumber");
   const formLat = document.getElementById("form-lat");
   const formLng = document.getElementById("form-lng");
 
   const options = {
     componentRestrictions: { country: "jp" },
-    fields: ["place_id", "geometry", "name", "formatted_address", "formatted_phone_number"],
+    fields: ["place_id", "geometry", "name", "formatted_address"],
     strictBounds: false,
   };
 
@@ -48,7 +47,6 @@ function initNewMap() {
     formnName.value = place.name;
     formPlaceId.value = place.place_id;
     formAddress.value = place.formatted_address.replace("日本、","");
-    formPhonenuber.value = place.formatted_phone_number;
     formLat.value = place.geometry.location.lat();
     formLng.value = place.geometry.location.lng();
   });

--- a/app/models/concerns/place_details.rb
+++ b/app/models/concerns/place_details.rb
@@ -1,0 +1,33 @@
+module PlaceDetails
+  extend ActiveSupport::Concern
+
+  included do
+    def add_google_map_uri
+      p uri = URI.parse("https://places.googleapis.com/v1/places/#{self.place_id}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme === "https"
+
+      p headers = {
+        "Content-Type" => "application/json",
+        "X-Goog-Api-Key" => ENV['PLACE_API_KEY'],
+        "X-Goog-FieldMask" => "googleMapsUri"
+      }
+
+      response = http.get(uri.path, headers)
+
+      case response
+
+      when Net::HTTPOK
+        res_body = JSON.parse(response.body)
+        if res_body.present?
+          self.google_map_uri = res_body["googleMapsUri"]
+        end
+      when Net::HTTPClientError
+        p response.code
+        p "client error: #{JSON.parse(response.body)["error"]["message"]}"
+      else
+        p "error status: #{response.code}"
+      end
+    end
+  end
+end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -8,7 +8,7 @@ class Shop < ApplicationRecord
   has_many :purchases, dependent: :destroy
   has_many :reviews, through: :purchases
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true
   validates :name, length: { maximum: 255 }
   validates :place_id, presence: true, uniqueness: true
   validates :place_id, length: { maximum: 255 }

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -10,7 +10,7 @@ class Shop < ApplicationRecord
   validates :name, length: { maximum: 255 }
   validates :place_id, presence: true, uniqueness: true
   validates :place_id, length: { maximum: 255 }
-  validates :address, presence: true, uniqueness: true
+  validates :address, presence: true
   validates :address, length: { maximum: 255 }
   validates :phone_number, length: { maximum: 15 }, if: -> { phone_number }
   validates :latitude, presence: true

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,4 +1,6 @@
 class Shop < ApplicationRecord
+  include PlaceDetails
+
   geocoded_by latitude: :latitude, longitude: :longitude
 
   has_many :dealers, dependent: :destroy
@@ -12,11 +14,12 @@ class Shop < ApplicationRecord
   validates :place_id, length: { maximum: 255 }
   validates :address, presence: true
   validates :address, length: { maximum: 255 }
-  validates :phone_number, length: { maximum: 15 }, if: -> { phone_number }
   validates :latitude, presence: true
   validates :latitude, numericality: { in: 20..46 }
   validates :longitude, presence: true
   validates :longitude, numericality: { in: 120..150 }
+  validates :google_map_uri, presence: true, uniqueness: true
+  validates :google_map_uri, length: { maximum: 255 }
 
   def self.ransackable_attributes(auth_object = nil)
     auth_object&.admin? ? super : %w(name place_id)

--- a/app/views/admin/beans/index.html.slim
+++ b/app/views/admin/beans/index.html.slim
@@ -32,4 +32,5 @@
             i.bi.bi-plus-circle-fill.me-1
             | Add
       = render @beans
+      br
       = paginate @beans

--- a/app/views/admin/brewing_methods/index.html.slim
+++ b/app/views/admin/brewing_methods/index.html.slim
@@ -18,4 +18,5 @@
       = turbo_frame_tag 'new_brewing_method'
       #brewing_methods
         = render @brewing_methods
+        br
         = paginate @brewing_methods

--- a/app/views/admin/purchases/edit.html.slim
+++ b/app/views/admin/purchases/edit.html.slim
@@ -5,8 +5,16 @@
       h1.mb-0 Edit purchase
       = link_to 'back', admin_purchases_path, class: 'btn btn-outline-danger'
     = bootstrap_form_with model: @purchase_form, url: admin_purchase_path(@purchase), class: 'mb-3' do |f|
-      = f.text_field :shop_name
-      = f.text_field :bean_name
+      .form-group.mb-3.position-relative[data-controller="autocomplete" data-autocomplete-url-value="/shops/search" role="combobox"]
+        = f.label :shop_name, Shop.human_attribute_name(:name), class: 'form-label'
+        = f.text_field :shop_name, wrapper: false, data: { autocomplete_target: "input" }
+        = f.hidden_field :shop_place_id, data: { autocomplete_target: "hidden" }
+        ul.z-1.list-group.position-absolute.top-100.start-0[data-autocomplete-target="results"]
+      .form-group.mb-3.position-relative[data-controller="autocomplete" data-autocomplete-url-value="/beans/search" role="combobox"]
+        = f.label :bean_name,Bean.human_attribute_name(:name), class: 'form-label'
+        = f.text_field :bean_name, wrapper: false , data: { autocomplete_target: "input" }
+        = f.hidden_field :bean_id, data: { autocomplete_target: "hidden" }
+        ul.list-group.position-absolute.top-100.start-0[data-autocomplete-target="results"]
       = f.select :store_roast_option, Purchase.store_roast_options.keys.to_a, prompt: 'roast'
       = f.select :store_grind_option, Purchase.store_grind_options.keys.to_a, prompt: 'fineness'
       = f.date_field :purchase_at

--- a/app/views/admin/purchases/index.html.slim
+++ b/app/views/admin/purchases/index.html.slim
@@ -29,4 +29,5 @@
           = sort_link(@q, :created_at, class: 'link-dark')
         .col-2
       = render @purchases
+      br
       = paginate @purchases

--- a/app/views/admin/regions/index.html.slim
+++ b/app/views/admin/regions/index.html.slim
@@ -18,4 +18,5 @@
       = turbo_frame_tag 'new_region'
       #regions
         = render @regions
+        br
         = paginate @regions

--- a/app/views/admin/reviews/index.html.slim
+++ b/app/views/admin/reviews/index.html.slim
@@ -28,4 +28,5 @@
           = sort_link(@q, :created_at, class: 'link-dark')
         .col-2
       = render @reviews
+      br
       = paginate @reviews

--- a/app/views/admin/shops/_form.html.slim
+++ b/app/views/admin/shops/_form.html.slim
@@ -6,9 +6,9 @@
   = f.text_field :name, id: 'form-name', placeholder: 'チェーン店は店舗名を最後まで入力してください'
   = f.text_field :place_id, id: 'form-place-id'
   = f.text_field :address, id: 'form-address'
-  = f.text_field :phone_number, id: 'form-phonenumber'
   = f.number_field :latitude, id: 'form-lat', step: '0.00000001'
   = f.number_field :longitude, id: 'form-lng', step: '0.00000001'
+  = f.text_field :google_map_uri
   css:
     #map-new {
       height: 25rem;

--- a/app/views/admin/shops/index.html.slim
+++ b/app/views/admin/shops/index.html.slim
@@ -30,4 +30,5 @@
             i.bi.bi-plus-circle-fill.me-1
             | Add
       = render @shops
+      br
       = paginate @shops

--- a/app/views/admin/tools/index.html.slim
+++ b/app/views/admin/tools/index.html.slim
@@ -18,4 +18,5 @@
       = turbo_frame_tag 'new_tool'
       #tools
         = render @tools
+        br
         = paginate @tools

--- a/app/views/admin/top_sliders/index.html.slim
+++ b/app/views/admin/top_sliders/index.html.slim
@@ -18,4 +18,5 @@
             | Add
       #top_sliders
         = render @top_sliders
+        br
         = paginate @top_sliders

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -24,4 +24,5 @@
           = sort_link(@q, :created_at, class: 'link-dark')
         .col-2
       = render @users
+      br
       = paginate @users

--- a/app/views/beans/search.html.slim
+++ b/app/views/beans/search.html.slim
@@ -1,3 +1,4 @@
 - @beans.each do |bean|
-  li.list-group-item.cursor-pointer[role="option" data-autocomplete-value="#{bean.id}" data-autocomplete-label="#{bean.name}"]
-    = bean.name
+  li.d-flex.list-group-item.cursor-pointer[role="option" data-autocomplete-value="#{bean.id}" data-autocomplete-label="#{bean.name}"]
+    span.me-2 = bean.name
+    span.fw-lighter = bean.shops.first.name

--- a/app/views/beans/show.html.slim
+++ b/app/views/beans/show.html.slim
@@ -7,7 +7,9 @@
         .text-center.col-10
           h4 = @bean.name
           h4 = @bean.region.name
-          p = @bean.shops.limit(2).pluck(:name).join(',')
+          - @shops.each do |shop|
+            = link_to shop.name, shops_path(q: { place_id_eq: shop.place_id }), class: 'link-dark me-2'
+          / p = @bean.shops.limit(2).pluck(:name).join(',')
           h4 = @bean.reviews.present? ? "#{Bean.human_attribute_name(:average_evaluation)} #{@bean.average_evaluation}" : ''
           h4 = "#{Bean.human_attribute_name(:roast)} #{@bean.roast_i18n}"
           - unless @bean.roast_raw?

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -6,4 +6,4 @@
     remote       : data-remote
 
 a.btn.btn-outline-secondary.disabled
-  == t('views.pagination.truncate').html_safe
+  | ...

--- a/app/views/purchases/_form.html.slim
+++ b/app/views/purchases/_form.html.slim
@@ -5,7 +5,7 @@
   .form-group.mb-3.position-relative[data-controller="autocomplete" data-autocomplete-url-value="/shops/search" role="combobox"]
     = f.label :shop_name, Shop.human_attribute_name(:name), class: 'form-label'
     = f.text_field :shop_name, wrapper: false, data: { autocomplete_target: "input" }
-    = f.hidden_field :shop_id, data: { autocomplete_target: "hidden" }
+    = f.hidden_field :shop_place_id, data: { autocomplete_target: "hidden" }
     ul.z-1.list-group.position-absolute.top-100.start-0[data-autocomplete-target="results"]
   .d-flex.align-items-center.justify-content-around
     p.mb-0 = t('defaults.no_candidates', item: Bean.model_name.human)

--- a/app/views/shared/_user_profile.html.slim
+++ b/app/views/shared/_user_profile.html.slim
@@ -5,7 +5,7 @@
         .d-flex.align-items-center.col-auto
           = image_tag user.avatar.url, class: 'rounded-circle me-3 avatar-preview p-0'
           h5.fs-4.mb-0 = user.name
-        - if user.same?(current_user)
+        - if current_user&.same?(user)
           = link_to t('defaults.edit'), edit_mypage_profile_path, class: 'col-auto px-3 badge rounded-pill text-decoration-none text-bg-secondary fs-5 ms-auto mt-2 shadow-sm', data: { turbo_frame: 'profile' }
       .mb-1
         label = User.human_attribute_name(:tools)

--- a/app/views/shops/_shop.html.slim
+++ b/app/views/shops/_shop.html.slim
@@ -7,8 +7,9 @@
     .accordion-collapse.col-12.collapse id="collapse#{shop.id}" aria-labelledby="heading#{shop.id}" data-bs-parent="#accordionShops"
       .accordion-body
         p.mb-2 = shop.address
-        .d-flex.justify-content-between.mb-1 data-controller='clip'
-          a.mb-2 href="#{shop.google_map_uri}" target="_blank" google mapで見る
+        .d-flex.justify-content-between.mb-1.align-items-center data-controller='clip'
+          a href="#{shop.google_map_uri}" target="_blank"
+            = t('shops.index.view_in_google_map')
           / a.btn.btn-dark href="https://twitter.com/share?url=#{shops_url(q: { place_id_eq: shop.place_id })}&text=#{shop.name}" target="_blank"
             = t('defaults.share_to_x')
           input.d-none data-clip-target="source" value="#{shops_url(q: { place_id_eq: shop.place_id })}" readonly="" type="text"

--- a/app/views/shops/_shop.html.slim
+++ b/app/views/shops/_shop.html.slim
@@ -8,7 +8,7 @@
       .accordion-body
         p.mb-2 = shop.address
         .d-flex.justify-content-between.mb-1 data-controller='clip'
-          p.mb-2 = shop.phone_number
+          a.mb-2 href="#{shop.google_map_uri}" target="_blank" google mapで見る
           / a.btn.btn-dark href="https://twitter.com/share?url=#{shops_url(q: { place_id_eq: shop.place_id })}&text=#{shop.name}" target="_blank"
             = t('defaults.share_to_x')
           input.d-none data-clip-target="source" value="#{shops_url(q: { place_id_eq: shop.place_id })}" readonly="" type="text"

--- a/app/views/shops/new.html.slim
+++ b/app/views/shops/new.html.slim
@@ -15,7 +15,6 @@
       = f.hidden_field :name, id: 'form-name'
       = f.hidden_field :place_id, id: 'form-place-id'
       = f.hidden_field :address, id: 'form-address'
-      = f.hidden_field :phone_number, id: 'form-phonenumber'
       = f.hidden_field :latitude, id: 'form-lat'
       = f.hidden_field :longitude, id: 'form-lng'
 

--- a/app/views/shops/search.html.slim
+++ b/app/views/shops/search.html.slim
@@ -1,3 +1,4 @@
 - @shops.each do |shop|
-  li.list-group-item.cursor-pointer[role="option" data-autocomplete-value="#{shop.id}" data-autocomplete-label="#{shop.name}"]
-    = shop.name
+  li.d-flex.list-group-item.cursor-pointer[role="option" data-autocomplete-value="#{shop.place_id}" data-autocomplete-label="#{shop.name}"]
+    span.me-2 = shop.name
+    span.fw-lighter = shop.address

--- a/app/views/user_profiles/_review.html.slim
+++ b/app/views/user_profiles/_review.html.slim
@@ -21,4 +21,5 @@
         .text-break
           = simple_format(h(review.content), class: 'mb-0')
         .d-flex.justify-content-end.fs-4 id="like_#{review.id}"
-          = render 'shared/like/likeicons', review: review
+          - if current_user
+            = render 'shared/like/likeicons', review: review

--- a/app/views/user_profiles/_review.html.slim
+++ b/app/views/user_profiles/_review.html.slim
@@ -5,7 +5,7 @@
         .d-flex.justify-content-start.col-12.align-items-center
           h5.me-3.mb-0 = review.title
           h6.mb-0 = review.purchase.bean.name
-    .accordion-collapse.col-12.collapse[id="collapse#{review.id}" aria-labelledby="heading#{review.id}" data-bs-parent="#accordionPurchases"]
+    .accordion-collapse.col-12.collapse[id="collapse#{review.id}" aria-labelledby="heading#{review.id}" data-bs-parent="#accordionReviews"]
       .accordion-body.pb-2
         .d-flex.justify-content-between
           p = review.purchase.roast_status
@@ -14,12 +14,19 @@
             i.bi.bi-star
             p = review.evaluation
           p = review.brewing_method.name
-        .d-flex.mb-2.pb-0.align-items-center
-          p.mb-0.me-1 = Review.human_attribute_name(:tool)
-          - review.tools.each do |tool|
-            span.badge.rounded-pill.text-bg-secondary.me-1 = tool.name
-        .text-break
-          = simple_format(h(review.content), class: 'mb-0')
+        .row
+          .col.me-1
+            .d-flex.mb-2.pb-0.align-items-center
+              p.mb-0.me-1.text-nowrap = Review.human_attribute_name(:tools)
+              .d-flex.align-items-center.flex-wrap
+                - review.tools.each do |tool|
+                  span.badge.rounded-pill.text-bg-secondary.me-1 = tool.name
+            .text-break.lh-1
+              = simple_format(h(review.content))
+          - if review.image.present?
+            .col-4.col-sm-3.col-lg-2.mt-auto.mb-3
+              = link_to image_review_path(review), class: 'd-block', data: { turbo_frame: 'modal' } do
+                = image_tag review.image.url, class: 'img-fluid shadow-sm'
         .d-flex.justify-content-end.fs-4 id="like_#{review.id}"
           - if current_user
             = render 'shared/like/likeicons', review: review

--- a/app/views/user_profiles/show.html.slim
+++ b/app/views/user_profiles/show.html.slim
@@ -19,7 +19,7 @@
         = sort_link(@q, :purchase_bean_name, class: 'link-dark ms-1')
         = sort_link(@q, :created_at, class: 'link-dark ms-1')
       - if @reviews.present?
-        .accordion#accordionreviews.accordion-flush
+        .accordion#accordionReviews.accordion-flush
           = render partial: 'review', collection: @reviews
         = paginate @reviews
       - else

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -109,6 +109,7 @@ ja:
       near_by_current_location: '現在地周辺の店舗'
       name_include: "%{item}を含む店舗"
       arround_tokyo: '東京駅周辺の店舗'
+      view_in_google_map: 'google mapで見る'
     new:
       title: '店舗登録'
       enter_your_location_from_the_map: 'マップから位置情報を入力してください'

--- a/db/migrate/20240404081313_add_google_map_uri_to_shops.rb
+++ b/db/migrate/20240404081313_add_google_map_uri_to_shops.rb
@@ -1,0 +1,6 @@
+class AddGoogleMapUriToShops < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :shops, :phone_number, :string
+    add_column :shops, :google_map_uri, :string
+  end
+end

--- a/db/migrate/20240406074710_fix_shops.rb
+++ b/db/migrate/20240406074710_fix_shops.rb
@@ -1,0 +1,6 @@
+class FixShops < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :shops, column: :name
+    add_index :shops, :place_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_04_081313) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_06_074710) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -146,7 +146,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_04_081313) do
     t.float "latitude"
     t.float "longitude"
     t.string "google_map_uri"
-    t.index ["name"], name: "index_shops_on_name", unique: true
+    t.index ["place_id"], name: "index_shops_on_place_id", unique: true
   end
 
   create_table "tools", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_23_084657) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_04_081313) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -145,7 +145,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_23_084657) do
     t.string "place_id", null: false
     t.float "latitude"
     t.float "longitude"
-    t.string "phone_number"
+    t.string "google_map_uri"
     t.index ["name"], name: "index_shops_on_name", unique: true
   end
 

--- a/lib/place_api/text_search.rb
+++ b/lib/place_api/text_search.rb
@@ -1,0 +1,60 @@
+def get_coffee_shop_from_viewport(lat, lng, lat_gap, lng_gap)
+  uri = URI.parse('https://places.googleapis.com/v1/places:searchText')
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = uri.scheme === "https"
+  
+  params = {
+    "textQuery" => 'コーヒー豆 販売店 焙煎所',
+    "languageCode" => "ja",
+    "regionCode" => "JP",
+    "locationRestriction" => {
+      "rectangle" => {
+        "low" => {
+          "latitude" => lat,
+          "longitude" => lng
+        },
+        "high" => {
+          "latitude" => lat + lat_gap,
+          "longitude" => lng + lng_gap
+        }
+      }
+    }
+  }
+  
+  headers = {
+    "Content-Type" => "application/json",
+    "X-Goog-Api-Key" => ENV['PLACE_API_KEY'],
+    "X-Goog-FieldMask" => "places.displayName,places.formattedAddress,places.id,places.location,places.googleMapsUri"
+  }
+  
+  response = http.post(uri.path, params.to_json, headers)
+  
+  case response
+
+  when Net::HTTPOK
+    p 'textsearch successful'
+    res_body = JSON.parse(response.body)
+    if res_body.empty?
+      return []
+    else
+      return res_body["places"]
+    end
+  when Net::HTTPClientError
+    p "client error #{JSON.parse(response.body)["error"]["message"]}"
+    return []
+  else
+    p "error status: #{response.code}"
+    return []
+  end
+end
+
+
+def save_shops(places)
+  places.each do |place|
+    next if Shop.find_by(place_id: place["id"])
+    p "found #{place["displayName"]["text"]}"
+    Shop.create!(name: place["displayName"]["text"], address: place["formattedAddress"], latitude: place["location"]["latitude"].to_f,
+                 longitude: place["location"]["longitude"].to_f, place_id: place["id"], google_map_uri: place["googleMapsUri"])
+    p "create #{place["displayName"]["text"]}"
+  end
+end

--- a/lib/tasks/get_shops.rake
+++ b/lib/tasks/get_shops.rake
@@ -1,0 +1,51 @@
+require './lib/place_api/text_search'
+
+namespace :get_shops do
+  task get_shop_in_tokyo: :environment do
+    reference_end_point = { lat: 35.82, lng: 139.93 }
+    lat_gap = 0.03
+    lng_gap = 0.014
+    search_lat = 35.54
+
+    while search_lat < reference_end_point[:lat] do
+      search_lng = 139.57
+
+      while search_lng < reference_end_point[:lng] do
+        p "searching location #{search_lat}, #{search_lng}"
+        search_result = get_coffee_shop_from_viewport(search_lat, search_lng, lat_gap, lng_gap)
+        save_shops(search_result)
+        search_lng = search_lng + lat_gap
+      end
+      search_lat = search_lat + lng_gap
+    end
+    
+    p 'Finish get shop in Tokyo!!'
+  end
+
+  task get_shop_in_kanto: :environment do
+    viewports = [
+      {low: {lat: 35.3, lng: 139.3}, high: {lat: 35.54, lng: 140.2}, gap: {lat: 0.12, lng: 0.1}},
+      {low: {lat: 35.54, lng: 139.3}, high: {lat: 35.82, lng: 139.57}, gap: {lat: 0.14, lng: 0.09}},
+      {low: {lat: 35.54, lng: 139.93}, high: {lat:35.82, lng: 140.2}, gap: {lat: 0.14, lng: 0.09}},
+      {low: {lat: 35.82, lng: 139.3}, high: {lat: 35.92, lng: 140.2},gap: {lat: 0.1, lng: 0.1}},
+    ]
+
+    viewports.each do |viewport|
+      search_lat = viewport[:low][:lat]
+      
+      while search_lat < viewport[:high][:lat] do
+        search_lng = viewport[:low][:lng]
+        
+        while search_lng < viewport[:high][:lng] do
+          p "searching location #{search_lat}, #{search_lng}"
+          search_result = get_coffee_shop_from_viewport(search_lat, search_lng, viewport[:gap][:lat], viewport[:gap][:lng])
+          save_shops(search_result)
+          search_lng = search_lng + viewport[:gap][:lng]
+        end
+        search_lat = search_lat + viewport[:gap][:lat]
+      end
+    end
+
+    p 'Finish get shop in capital city area!!'
+  end
+end


### PR DESCRIPTION
首都圏のみで実装

- [x] rake task 作成
- [x] Shopsテーブルにgoogle map uriを追加、電話番号を削除
  - [x] 店舗一覧のパーシャルにリンクを追加
- [x] kaminari, プロフィール閲覧機能のビューを修正
- [x] 店舗登録機能から電話番号を削除、google_map_uriを追加するメソッドを追加
- [x] 購入記録フォームを店舗名、商品名の重複に対応するように修正